### PR TITLE
docs: update main README and add demo setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ omnixtend/
 ├── tools/                # Utility applications for traffic generation, analysis, and debugging
 ├── examples/             # End-to-end system examples for simulation and FPGA deployment
 ├── docs/                 # Architecture notes, design documents, and OmniXtend standard specs
+├── demo/                 # Demonstration setups with detailed instructions
 ├── scripts/              # Common environment setup and build scripts
 ├── LICENSE               # Apache 2.0 License
 └── README.md             # Project overview and instructions
@@ -51,12 +52,27 @@ omnixtend/
   - Combines components from `-c`, `-verilog`, and `-chisel` to create functional test platforms.
   - Targeted for FPGA deployments, end-to-end validation, and educational use.
 
+- **`demo/`**
+  - Self-contained demonstrations showcasing OmniXtend in action.
+  - Includes setup scripts, example configurations, and expected outputs.
+  - **To run a demo**, refer to the detailed guide in [`demo/README.md`](demo/README.md).
+
 - **`docs/`**
   - Documentation hub for the entire project.
   - Contains architecture overviews, technical notes, and protocol specification documents.
   - Includes the official *OmniXtend standard documents* used for reference and compliance.
 
 ## 🚀 Getting Started
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/your-org/omnixtend.git
+   cd omnixtend
+   ```
+
+2. Refer to component-specific directories and their `README.md` files for detailed build and run instructions.
+
+3. For a hands-on demo, see [`demo/README.md`](demo/README.md).
 
 ## 📚 References
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,70 @@
+# OmniXtend Demo Setup
+
+This guide describes how to set up and run a demonstration of the OmniXtend memory coherence protocol using FPGA platforms. The demo includes a host node and a memory node, operating over an Ethernet-based coherence protocol.
+
+---
+
+## 🧩 Hardware Configuration
+
+- **Host Node**: Xilinx VCU118
+- **Memory Node**: Xilinx AU280
+- **Vivado Version**: 2021.2
+- **SD Card**: SanDisk 16GB (used for OS boot)
+- **Connection**: SD card connects to VCU118 via PMOD adapter
+
+---
+
+## 📀 Operating System Image
+
+Download the OS image (`sdcard.img`) from the [Releases](../../releases) section of this repository.
+
+To write the image to the SD card, use:
+
+```bash
+sudo dd if=./sdcard.img of=/dev/sdX bs=4k status=progress
+```
+
+> Replace `/dev/sdX` with the appropriate device identifier for your SD card.
+
+### SD Card Content Layout
+
+```
+├── latmem
+│   ├── latmem
+│   ├── latmem.c
+│   ├── latmemfar
+│   ├── latmemfar.c
+│   ├── Makefile
+│   └── README.md
+├── lost+found
+├── sgemm_meca
+├── sgemm_meca2
+├── sortbench
+└── stream_c.exe
+```
+
+---
+
+## ⚙️ System Setup Instructions
+
+1. Write the appropriate bitstream to **both** the host (VCU118) and memory (AU280) nodes using Vivado 2021.2.
+2. Power **on the AU280** memory node **first** and wait until it stabilizes.
+3. Insert the prepared SD card into the VCU118 (via PMOD adapter).
+4. Power **on the VCU118**. The operating system should boot, visible through UART.
+5. Once booted, log in with:
+   ```
+   Username: root
+   Password: fpga
+   ```
+6. The memory-mapped range `0x200000000 ~ 0x3FFFFFFFF` is accessible and backed by the memory node.
+7. Use the `devmem` utility to verify memory access and perform read/write operations.
+
+---
+
+## 📊 Running Benchmarks
+
+Benchmark tests are included in the SD card image but execution procedures are **TBD (To Be Defined)**. Please refer to the top-level `latmem`, `sortbench`, and `sgemms` binaries on the SD card for performance validation tools.
+
+More detailed benchmark usage instructions will be provided in future updates.
+
+---


### PR DESCRIPTION
This PR includes the following documentation updates:

1. **Main `README.md` Update**
   - Added `demo/` folder to repository structure
   - Provided guidance on running demo via `demo/README.md` reference
   - Clarified usage flow and component descriptions

2. **New `demo/README.md`**
   - Introduced a detailed setup guide for the OmniXtend demo
   - Hardware setup includes VCU118 (host) and AU280 (memory)
   - Instructions for SD card image flashing, OS boot, UART login, and memory access
   - Placeholder for benchmark execution steps (TBD)

These changes improve onboarding clarity and support users in reproducing the FPGA-based OmniXtend demo.