### PR TITLE
docs: fix TLoE spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **OmniXtend** is an open, Ethernet-based memory coherence protocol that extends RISC-V’s memory model across distributed systems.  
 This repository provides a unified, modular workspace for developing, testing, and deploying OmniXtend components using **C**, **Verilog RTL**, and **Chisel** implementations.
 
-Each component is organized for compatibility with industry and research frameworks such as **TLEO** and **Chipyard**, enabling practical integration with host machines, memory nodes, and FPGA-based SoC systems.
+Each component is organized for compatibility with industry and research frameworks such as **TLoE** and **Chipyard**, enabling practical integration with host machines, memory nodes, and FPGA-based SoC systems.
 
 ## 📁 Repository Structure
 


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Correct `TLEO` to `TLoE` in the README compatibility sentence.

Fixes #1

## Test plan
- static validation: `TLEO` appeared 1 time(s) in `README.md` before replacement.
- static validation: `TLEO` absent and `TLoE` present in `README.md` after patch.
- Not run: runtime test suite, because this is a documentation-only fix.
